### PR TITLE
Add Java in order to run amplify moc

### DIFF
--- a/images/latest/Dockerfile
+++ b/images/latest/Dockerfile
@@ -134,4 +134,6 @@ $PATH" >> ~/.bashrc && \
     echo export GEM_PATH="/usr/local/rvm/gems/ruby-${VERSION_RUBY_DEFAULT}" >> ~/.bashrc && \
     echo "nvm use ${VERSION_NODE_DEFAULT} 1> /dev/null" >> ~/.bashrc
 
+RUN amazon-linux-extras install java-openjdk11
+
 ENTRYPOINT [ "bash", "-c" ]


### PR DESCRIPTION
*Description of changes:*

This PR adds java to the build image in order to run amplify mock.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
