### PR TITLE
amplifyPush: Bypass Setting $ENV if Provided As an Argument

### DIFF
--- a/scripts/amplifyPush.sh
+++ b/scripts/amplifyPush.sh
@@ -62,15 +62,16 @@ while [[ $# -gt 0 ]]
 done
 set -- "${POSITIONAL[@]}"
 
-# if no provided environment name, use default env variable, then user override
-if [[ ${ENV} = "" ]];
+# If no environment has been provided, perform some checks in order to set ENV
+if [[ -z ${ENV} ]];
 then
-    ENV=${AWS_BRANCH}
-fi
-
-if [[ ${USER_BRANCH} != "" ]];
-then
-    ENV=${USER_BRANCH}
+    # If USER_BRANCH is available, use that, othewise use git branch name as default
+    if [[ ! -z ${USER_BRANCH} ]];
+    then
+        ENV=${USER_BRANCH}
+    else 
+        ENV=${AWS_BRANCH}
+    fi
 fi
 
 # strip slashes, limit to 10 chars


### PR DESCRIPTION
*Issue #, if available:*

#524 

*Description of changes:*

Update to `amplifyPush`.

I modified the conditional logic around setting $ENV. I found that even if you pass something like `-e stg` it gets overridden by the `USER_BRANCH` environment variable. See this bit of code:

https://github.com/aws-amplify/amplify-console/blob/master/scripts/amplifyPush.sh#L71-L74

Basically, if a value is provided to `amplifyPush` through the environment argument `--environment, -e` then we do not want to override that explicit directive. If it's not provided, then apply the same behavior as before.

One caveat here, I do not really know what the intended use of the `USER_BRANCH` variable is. I know Amplify is creating that for us. I may not understand the bigger scope of how this should work but I do know that if an argument is provided to the script, we should probably not be overriding an explicitly set value.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
