### PR TITLE
Also install amplify-cli for Node.js 12

### DIFF
--- a/images/latest/Dockerfile
+++ b/images/latest/Dockerfile
@@ -112,11 +112,11 @@ RUN /bin/bash -c ". ~/.nvm/nvm.sh && \
     nvm use ${VERSION_NODE_DEFAULT} && \
     npm install -g --unsafe-perm=true --allow-root cypress"
 
-## Install AWS Amplify CLI for VERSION_NODE_DEFAULT and VERSION_NODE_10
+## Install AWS Amplify CLI for VERSION_NODE_DEFAULT and VERSION_NODE_12
 RUN /bin/bash -c ". ~/.nvm/nvm.sh && nvm use ${VERSION_NODE_DEFAULT} && \
     npm config set user 0 && npm config set unsafe-perm true && \
 	npm install -g @aws-amplify/cli@${VERSION_AMPLIFY}"
-RUN /bin/bash -c ". ~/.nvm/nvm.sh && nvm use ${VERSION_NODE_10} && \
+RUN /bin/bash -c ". ~/.nvm/nvm.sh && nvm use ${VERSION_NODE_12} && \
     npm config set user 0 && npm config set unsafe-perm true && \
 	npm install -g @aws-amplify/cli@${VERSION_AMPLIFY}"
 


### PR DESCRIPTION
Currently the amplify-cli is installed for Node.js 10 only.
With this change it is possible to use Node.js 12 throughout the whole amplify build process without getting the following error when pushing the amplify backend:

```
2020-08-06T14:07:40.389Z [INFO]: # Executing command: amplifyPush --simple
2020-08-06T14:07:40.391Z [WARNING]: /codebuild/output/***/amplify.sh: line 14: amplify: command not found
```

*Description of changes:*

Since node 10 is set as the default node version it doesnt seem necessary to install amplify-cli for the default node version and node 10, so this commit installs the amplify-cli for node 12 instead of node 10.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
