### PR TITLE
Provide details on minimum build timeout

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -46,7 +46,7 @@ backend:
 
 ### How do I override a build timeout?
 
-The default build timeout is 30 minutes, if your build takes more than 30 minutes, you can override the default build timeout using an environment variable: `_BUILD_TIMEOUT` (App settings > Environment variables).
+The default build timeout is 30 minutes. You can override the default build timeout using an environment variable: `_BUILD_TIMEOUT` (App settings > Environment variables). The minimum build timeout is 5 minutes.
 
 ### How do I pull private packages during a build?
 


### PR DESCRIPTION
<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-console/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

I was trying to test a shorter build timeout (set to `1`) and it wasn't working. Support let me know that the minimum build timeout is `5`. This would be helpful to have documented (if there's a max, that'd be helpful to know about too).

#### Issue #, if available

Support ticket: 8354618101

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
