### PR TITLE
Removed env variable docs to disable cache

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -126,7 +126,7 @@ cache:
 
 #### How do I disable reading from cache?
 
-You can either remove the cache section from your buildspec or set the `AWS_CACHE_BUCKET_READ` environment variable. To disable with the environment variable and leave cache in your buildspec, set the `AWS_CACHE_BUCKET_READ` environment variable to `false` in `App settings > Environment variables`.
+Remove the cache section from your buildspec.
 
 ## Redirects
 


### PR DESCRIPTION
Any variable prefixed with AWS is not developer settable.  Removed it because it doesn't work.

<!--
Please make sure to read the Pull Request Guidelines:
https://github.com/aws-amplify/amplify-console/blob/master/CONTRIBUTING.md#pull-requests
-->

#### Description of changes

<!--
Thank you for your Pull Request! Please provide a description above and review
the requirements below.
-->

#### Issue #, if available
N/A

<!-- Also, please reference any associated PRs for documentation updates. -->

#### Checklist

<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] PR description included

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
